### PR TITLE
Update shortcodes.php

### DIFF
--- a/bootstrap/shortcodes.php
+++ b/bootstrap/shortcodes.php
@@ -7,6 +7,6 @@ $shortcode->add(
     'socializr',
     'Socializr::showSet',
     [
-        'slug' => 'handle'
+        'handle' => 'slug'
     ]
 );


### PR DESCRIPTION
Fixes PDO Exception. handle and slug was switched. The first parameter is the one used in the shortcode, the second one in the functions passed to. See http://getherbert.com/0.9/shortcodes
